### PR TITLE
Create a smaller image...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,10 @@ VOLUME /mnt/routes
 EXPOSE 80
 
 COPY ./build-env.sh /src/
-RUN cd /src && ./build-env.sh
 COPY ./build-glide.sh ./glide.yaml ./glide.lock /src/
-RUN cd /src && ./build-glide.sh
 COPY . /src/
-RUN chmod +x /src/entrypoint.sh
-RUN apk update
-RUN apk add curl
-RUN cd /src && ./build.sh "$(cat VERSION)"
+RUN cd /src && ./build-env.sh \
+       && ./build-glide.sh \
+       && chmod +x /src/entrypoint.sh \
+       && apk --no-cache add curl \
+       &&  ./build.sh "$(cat VERSION)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ ENTRYPOINT ["/src/entrypoint.sh"]
 VOLUME /mnt/routes
 EXPOSE 80
 
-COPY ./build-env.sh /src/
-COPY ./build-glide.sh ./glide.yaml ./glide.lock /src/
 COPY . /src/
 RUN cd /src && ./build-env.sh \
        && ./build-glide.sh \

--- a/build-env.sh
+++ b/build-env.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -e
-apk add --update go build-base git mercurial ca-certificates rsync
+apk add --no-cache go build-base git mercurial ca-certificates rsync


### PR DESCRIPTION
 at the expense of a potentially longer-lasting build (about 1m15s)

20MB image instead of 783MB !!! I think this is important, especially for utility images like this which get downloaded onto every new host.